### PR TITLE
verification if the hostname is not used by the server alias tab.

### DIFF
--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Hosts.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Hosts.php
@@ -30,3 +30,5 @@ $L['Update_Alias_Header'] = 'Update alias "${0}"';
 $L['Create_Dns_Header'] = 'Create a new host name';
 $L['Update_Dns_Header'] = 'Update host name "${0}"';
 $L['valid_platform,host-delete,fwobject-referenced,3'] = 'Could not delete ${2}. The host is used by firewall rules.';
+$L['hostname'] = 'Hostname';
+$L['Service_key_exists_message'] = 'This hostname is already used in the host database';

--- a/root/usr/share/nethesis/NethServer/Module/Hosts/Dns/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Module/Hosts/Dns/Modify.php
@@ -51,6 +51,13 @@ class Modify extends \Nethgui\Controller\Table\Modify
                 $report->addValidationError($this, 'Key', $v);
             }
         }
+
+        #a key can be  'remote or self' and must not be overwritten
+        $keyExists = $this->getPlatform()->getDatabase('hosts')->getType($this->parameters['hostname']) != '';
+        if($this->getIdentifier() === 'create' && $keyExists) {
+        $report->addValidationErrorMessage($this, 'hostname', 'Service_key_exists_message');
+        }
+
         parent::validate($report);
     }
 


### PR DESCRIPTION
it is possible and easy to verify if the key is not used before to overwrite it with a new type for the host tab, but my solution doesn't work for the server alias tab.
I can see that the server alias tab is written with an old way (one file rather than two files like the host tab, done in 2011). Do it is valuable to code it again with a modern way
